### PR TITLE
ci: mark workspace as safe for e2e

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Mark workspace as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Install Dependencies
         uses: ./.github/actions/setup
 


### PR DESCRIPTION
## Goals/Scope

Mark workspace as safe for e2e testing to enable end-to-end tests to run properly.